### PR TITLE
Fixed typos in Strings.ipynb

### DIFF
--- a/Strings.ipynb
+++ b/Strings.ipynb
@@ -166,7 +166,7 @@
    "source": [
     "## Printing a String\n",
     "\n",
-    "Using iPython notebook with just a string in a cell will automatically output strings, but the correct way to display strings in your output is by using a print function."
+    "Using Jupyter notebook with just a string in a cell will automatically output strings, but the correct way to display strings in your output is by using a print function."
    ]
   },
   {
@@ -270,7 +270,7 @@
     "\n",
     "If you want to use this functionalty in Python2, you can import form the __future__ module. \n",
     "\n",
-    "**A word of caution, after importing this you won't be able to choose the print statement method anymore. So pick whichever one you prefer depending on your Python installation and continnue on with it.**"
+    "**A word of caution, after importing this you won't be able to choose the print statement method anymore. So pick whichever one you prefer depending on your Python installation and continue on with it.**"
    ]
   },
   {
@@ -338,12 +338,12 @@
     "## String Indexing\n",
     "We know strings are a sequence, which means Python can use indexes to call parts of the sequence. Let's learn how this works.\n",
     "\n",
-    "In Python, we use brackets [] after an object to call it's index. We should also note that indexing starts at 0 for Python. Let's create a new object called s and the walk through a few examples of indexing."
+    "In Python, we use brackets [] after an object to call its index. We should also note that indexing starts at 0 for Python. Let's create a new object called s and the walk through a few examples of indexing."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 1,
    "metadata": {
     "collapsed": true
    },
@@ -714,7 +714,7 @@
    },
    "source": [
     "## String Properties\n",
-    "Its important to note that strings have an important property known as immutability. This means that once a string is created, the elements within it can not be changes or replaced. For example:"
+    "Its important to note that strings have an important property known as immutability. This means that once a string is created, the elements within it can not be changed or replaced. For example:"
    ]
   },
   {
@@ -1092,8 +1092,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##Next up: Lists!"
+    "## Next up: Lists!"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1112,7 +1121,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed typo: “continnue” to “continue” in the last line of the Python 3 Alert
Under “String Indexing” changed “In Python, we use brackets [] after an object to call it's index” to
“In Python, we use brackets [] after an object to call its index”
In “String Properties” changed “elements within it can not be changes or replaced” to
“elements within it can not be changed or replaced”
Last line: added a space after the hashes to make it show up as a heading in Markdown.
