### PR TITLE
Type cast the integer input

### DIFF
--- a/Errors and Exceptions Homework - Solution.ipynb
+++ b/Errors and Exceptions Homework - Solution.ipynb
@@ -93,7 +93,7 @@
     "    \n",
     "    while True:\n",
     "        try:\n",
-    "            n = input('Input an integer: ')\n",
+    "            n = int(input('Input an integer: '))\n",
     "        except:\n",
     "            print 'An error occured! Please try again!'\n",
     "            continue\n",


### PR DESCRIPTION
If you don't type cast the integer input the error will only occur when the value for n is being squared and will not be caught by the except.
