### PR TITLE
Update Jupyter (iPython) Notebooks Guide.ipynb

### DIFF
--- a/Jupyter (iPython) Notebooks Guide.ipynb
+++ b/Jupyter (iPython) Notebooks Guide.ipynb
@@ -7,7 +7,7 @@
     "# Guide to Using Jupyter Notebooks\n",
     "In this lecture we will be going over the basics of the Jupyter (previously called iPython Notebooks).\n",
     "\n",
-    "For a complete User Manual check out the [Bryn Mawr College Computer Science Guide](http://jupyter.cs.brynmawr.edu/hub/dblank/public/Jupyter%20Notebook%20Users%20Manual.ipynb).\n",
+    "For a complete User Manual check out the [Bryn Mawr College Computer Science Guide](https://athena.brynmawr.edu/jupyter/hub/dblank/public/Jupyter%20Notebook%20Users%20Manual.ipynb).\n",
     "\n",
     "Most of the breakdown will actually occur in the presentation corresponding to this Notebook. So please refer to either the presentation or the full User Manual linked above."
    ]


### PR DESCRIPTION
Corrected broken link for "Bryn Mawr College Computer Science Guide":

instead of:
https://athena.brynmawr.edu/hub/dblank/public/Jupyter%20Notebook%20Users%20Manual.ipynb

should be:
https://athena.brynmawr.edu/jupyter/hub/dblank/public/Jupyter%20Notebook%20Users%20Manual.ipynb

Best regards,
Predrag Rogic
