### PR TITLE
Corrected the self subtraction output

### DIFF
--- a/Dictionaries.ipynb
+++ b/Dictionaries.ipynb
@@ -227,7 +227,7 @@
     {
      "data": {
       "text/plain": [
-       "-123"
+       "0"
       ]
      },
      "execution_count": 17,


### PR DESCRIPTION
I have updated the output for the In[17] where the self-subtraction performed.

```python
# Set the object equal to itself minus 123 
my_dict['key1'] -= 123
my_dict['key1']

```
Output should be 0 and not -123