### PR TITLE
Update deprecated Latex call to use Label instead

### DIFF
--- a/GUI/3 - Widget Events.ipynb
+++ b/GUI/3 - Widget Events.ipynb
@@ -304,7 +304,7 @@
    "outputs": [],
    "source": [
     "# Create Caption\n",
-    "caption = widgets.Latex(value = 'The values of slider1 and slider2 are synchronized')\n",
+    "caption = widgets.Label(value = 'The values of slider1 and slider2 are synchronized')\n",
     "\n",
     "# Create IntSlider\n",
     "slider1 = widgets.IntSlider(description='Slider 1')\n",
@@ -326,7 +326,7 @@
    "outputs": [],
    "source": [
     "# Create Caption\n",
-    "caption = widgets.Latex(value = 'Changes in source values are reflected in target1')\n",
+    "caption = widgets.Label(value = 'Changes in source values are reflected in target1')\n",
     "\n",
     "# Create Sliders\n",
     "source = widgets.IntSlider(description='Source')\n",
@@ -380,7 +380,7 @@
    "outputs": [],
    "source": [
     "# NO LAG VERSION\n",
-    "caption = widgets.Latex(value = 'The values of range1 and range2 are synchronized')\n",
+    "caption = widgets.Label(value = 'The values of range1 and range2 are synchronized')\n",
     "\n",
     "range1 = widgets.IntSlider(description='Range 1')\n",
     "range2 =  widgets.IntSlider(description='Range 2')\n",
@@ -398,7 +398,7 @@
    "outputs": [],
    "source": [
     "# NO LAG VERSION\n",
-    "caption = widgets.Latex(value = 'Changes in source_range values are reflected in target_range1')\n",
+    "caption = widgets.Label(value = 'Changes in source_range values are reflected in target_range1')\n",
     "\n",
     "source_range = widgets.IntSlider(description='Source range')\n",
     "target_range1 = widgets.IntSlider(description='Target range ')\n",


### PR DESCRIPTION
Prevent deprecated messages in python 2 from Latex command.  Use Label instead.