### PR TITLE
Update Lambda expressions

### DIFF
--- a/Lambda expressions.ipynb
+++ b/Lambda expressions.ipynb
@@ -355,7 +355,7 @@
    "metadata": {},
    "source": [
     "##Example 4\n",
-    "Just like a normal function, we can accept more than one function into a lambda expression:"
+    "Just like a normal function, we can accept more than one argument into a lambda expression:"
    ]
   },
   {


### PR DESCRIPTION
Uhm, I guess it was a mistake, I edited the Example 4 part, substituting function for argument:
Before: Just like a normal function, we can accept more than one **function** into a lambda expression
After: Just like a normal function, we can accept more than one **argument** into a lambda expression